### PR TITLE
Fix aspect ratio for generated pixel art in web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 **/__pycache__
 images/*
 !images/.gitkeep
+static/IMG/*
+!static/IMG/.gitkeep

--- a/community_version.py
+++ b/community_version.py
@@ -47,7 +47,7 @@ def map_pixels_to_ascii_chars(image, range_width, ASCII_CHARS):
     return "".join(pixels_to_chars)
 
 
-def convert_image_to_ascii(image, range_width, new_width=100, ASCII_CHARS=None):
+def convert_image_to_ascii(image, range_width, new_width=100, ASCII_CHARS=None, fix_aspect_ratio=False):
     # set default ascii character list
     if ASCII_CHARS == None:
         ASCII_CHARS = ["#", "?", "%", ".", "S", "+", ".", "*", ":", ",", "@"]
@@ -62,6 +62,15 @@ def convert_image_to_ascii(image, range_width, new_width=100, ASCII_CHARS=None):
         pixels_to_chars[index : index + new_width]
         for index in range(0, len_pixels_to_chars, new_width)
     ]
+
+    if fix_aspect_ratio:
+        # The generated ascii image is approximately 1.35 times
+        # larger than the original image
+        # So, we will drop one line after every 3 lines
+        image_ascii = [
+            char for index, char in enumerate(image_ascii) 
+            if index % 4 != 0
+        ]
 
     return "\n".join(image_ascii)
 

--- a/webapp/ascii_art.py
+++ b/webapp/ascii_art.py
@@ -68,7 +68,7 @@ def upload_file():
 
             ASCII_CHARS = ["#", "?", "%", ".", "S", "+", ".", "*", ":", ",", "@"]
             range_width = 25
-            ascii_ = convert_image_to_ascii(img, range_width, ASCII_CHARS=ASCII_CHARS)
+            ascii_ = convert_image_to_ascii(img, range_width, ASCII_CHARS=ASCII_CHARS, fix_aspect_ratio=True)
             file.close()
 
             try:
@@ -99,7 +99,7 @@ def gallery(file_path=""):
         filepath = os.path.join(app.config["UPLOAD_FOLDER"], filename)
         img = Image.open(filepath)
         range_width = ceil((255 + 1) / len(CHAR_SET))
-        ascii_ = convert_image_to_ascii(img, range_width, ASCII_CHARS=CHAR_SET)
+        ascii_ = convert_image_to_ascii(img, range_width, ASCII_CHARS=CHAR_SET, fix_aspect_ratio=True)
         return render_template("ascii_2.html", ascii=ascii_)
 
     return render_template("gallery.html", imagelist=IMG_LIST)


### PR DESCRIPTION
The generated ASCII art in the web app is way too stretched vertically. Applied a factor to remove every 5th line, so that the aspect ratio looks near-perfect.