### PR TITLE
Adding link to legacy version on v2

### DIFF
--- a/webapp/templates/base-v2.html
+++ b/webapp/templates/base-v2.html
@@ -17,6 +17,7 @@
                 <li class="image-link"><a href="/v2">Image</a></li>
                 <li class="gallery-link"><a href="/v2/gallery">Gallery</a></li>
                 <li class="text-link"><a href="/v2/text">Text</a></li>
+                <li class="text-link"><a href="/">Old Version</a></li>
                 <div class="darkmode-switch" id="darkmode-switch">
                     <label>
                         <input type="checkbox" id="darkmode-input" checked>


### PR DESCRIPTION
The webapp has two versions: default version and new version. If a user navigates to new version, there is no link to navigate back to the default version. This PR solves this pain point by adding a link from new version to default version – so that the user can navigate back and reach the original state.